### PR TITLE
fix: add noEmit to tsconfig to prevent ts from transforming ts files,…

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"paths": {"*": ["types/*"]},
 		"moduleResolution": "node",
-		"outDir": "./dist/",
+		"noEmit": true,
 		"sourceMap": true,
 		"jsx": "react",
 		"module": "commonjs",


### PR DESCRIPTION
add noEmit to tsconfig to prevent ts from transforming ts files, allow Babel to do the transformation